### PR TITLE
feat(node): dial peers on startup

### DIFF
--- a/safenode/src/client/api.rs
+++ b/safenode/src/client/api.rs
@@ -70,6 +70,8 @@ impl Client {
         match event {
             // Clients do not handle requests.
             NetworkEvent::RequestReceived { .. } => {}
+            // We do not listen on sockets.
+            NetworkEvent::NewListenAddr(_) => {}
             NetworkEvent::PeerAdded => {
                 self.events_channel
                     .broadcast(ClientEvent::ConnectedToNetwork);

--- a/safenode/src/node/mod.rs
+++ b/safenode/src/node/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     storage::{ChunkStorage, RegisterStorage},
 };
 
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use xor_name::{XorName, XOR_NAME_LEN};
 
@@ -33,6 +33,8 @@ pub struct Node {
     registers: RegisterStorage,
     transfers: Transfers,
     events_channel: NodeEventsChannel,
+    /// Peers that are dialed at startup of node.
+    initial_peers: Vec<(PeerId, Multiaddr)>,
 }
 
 /// A unique identifier for a node in the network,


### PR DESCRIPTION
We dial optional peers on startup that will get added to our routing
table et al. This will cause our node to get booted by specifying a
bootstrap node address.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f3946cd</samp>

### Summary
🎧📢🤝

<!--
1.  🎧 - This emoji represents the addition of a match arm to handle the `NewListenAddr` event, which is related to listening on sockets and networking.
2.  📢 - This emoji represents the addition of a new `NetworkEvent` variant to broadcast the new listen addresses of the `SwarmDriver`, which is also related to networking and communication.
3.  🤝 - This emoji represents the addition of the ability to dial initial peers at startup, which is related to establishing connections and peer-to-peer interactions.
-->
This pull request enhances the network connectivity of the node and client by adding and handling a new event for new listen addresses, and by allowing the node to dial initial peers at startup. It modifies the `NetworkEvent` enum, the `SwarmDriver` struct, and the `NodeConfig` struct, as well as the `api.rs` and `mod.rs` files in the `node` and `client` modules.

> _`Node` dials peers_
> _New listen addresses flow_
> _Autumn network grows_

### Walkthrough
*  Add a new variant to the `NetworkEvent` enum to communicate new listen addresses from the `SwarmDriver` to the `Client` or `Node` ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-bdedb3eebbf1e1f6ac874697577200abcd9366e2fcefb9e73dbbe8f127698872R72-R73))
*  Modify the `SwarmDriver` to send the new listen address as a `NetworkEvent::NewListenAddr` to the `event_sender` channel when it receives a `SwarmEvent::NewListenAddr` from the `Swarm` ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-bdedb3eebbf1e1f6ac874697577200abcd9366e2fcefb9e73dbbe8f127698872L151-R157))
*  Ignore the `NetworkEvent::NewListenAddr` in the `Client` as it does not need to listen on sockets ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-5256d871e6753c72a1b2df3704b78f85cdbc5a4baa77853a8611ad2d1e77c1a9R73-R74))
*  Handle the `NetworkEvent::NewListenAddr` in the `Node` by spawning a task that tries to dial the `initial_peers` using the new listen address ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-ae93be614203f23a4b33e38e2ac1aafcf961ae7d4e6ac9485fae33eb475e0938R106-R116))
*  Add a new parameter `initial_peers` to the `run` function and the `Node` struct to store the peer id and address of the peers that the node can dial at startup ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-ae93be614203f23a4b33e38e2ac1aafcf961ae7d4e6ac9485fae33eb475e0938L51-R54), [link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-ae93be614203f23a4b33e38e2ac1aafcf961ae7d4e6ac9485fae33eb475e0938R65))
*  Add a new field `initial_peers` to the `NodeConfig` struct to configure the node with the peers that it can dial at startup ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-97ee839e6671f0e55da625149f1ade2dfda4a80bd11103aceaa5f714255a6a87R36-R37))
*  Add the `Multiaddr` import to the `safenode/src/client/api.rs`, `safenode/src/node/api.rs`, and `safenode/src/node/mod.rs` files as it is used to represent the addresses of the peers ([link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-bdedb3eebbf1e1f6ac874697577200abcd9366e2fcefb9e73dbbe8f127698872L22-R22), [link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-ae93be614203f23a4b33e38e2ac1aafcf961ae7d4e6ac9485fae33eb475e0938L33-R33), [link](https://github.com/maidsafe/safe_network/pull/2269/files?diff=unified&w=0#diff-97ee839e6671f0e55da625149f1ade2dfda4a80bd11103aceaa5f714255a6a87L23-R23))


